### PR TITLE
implemented vendor id field in avp header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 npm-debug.log
 node_modules
 dictionary.json
+.idea/

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+.DS_Store
+npm-debug.log
+node_modules
+dictionary.json

--- a/dictionaries/Cisco.xml
+++ b/dictionaries/Cisco.xml
@@ -1,6 +1,277 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 	<application id="16777238" name="3GPP Gx" uri="http://www.ietf.org/internet-drafts/draft-ietf-aaa-diameter-cc-06.txt">
+	
+	<command name="Credit-Control" code="272" vendor-id="None"/>
+
+	<!-- ************************* DCCA AVPs ************************ -->
+	<!-- This list is not complete yet -->
+	<avp name="CC-Correlation-Id" code="411" mandatory="may" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="CC-Input-Octets" code="412" mandatory="must">
+		<type type-name="Unsigned64"/>
+	</avp>
+	<avp name="CC-Money" code="413" mandatory="must">
+		<grouped>
+			<gavp name="Unit-Value"/>
+			<gavp name="Currency-Code"/>
+		</grouped>
+	</avp>
+
+	<avp name="CC-Output-Octets" code="414" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<type type-name="Unsigned64"/>
+	</avp>
+	<avp name="CC-Request-Number" code="415" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="CC-Request-Type" code="416" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<type type-name="Unsigned32"/>
+		<enum name="INITIAL_REQUEST"     code="1"/>
+		<enum name="UPDATE_REQUEST"      code="2"/>
+		<enum name="TERMINATION_REQUEST" code="3"/>
+		<enum name="EVENT_REQUEST"       code="4"/>
+	</avp>
+	<avp name="CC-Service-Specific-Units" code="417" mandatory="must">
+		<type type-name="Unsigned64"/>
+	</avp>
+	<avp name="CC-Session-Failover" code="418" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<type type-name="Enumerated"/>
+		<enum name="FAILOVER_NOT_SUPPORTED" code="0"/>
+		<enum name="FAILOVER_SUPPORTED" code="1"/>
+	</avp>
+	<avp name="CC-Sub-Session-Id" code="419" mandatory="must">
+		<type type-name="Unsigned64"/>
+	</avp>
+	<avp name="CC-Time" code="420" mandatory="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="CC-Total-Octets" code="421" mandatory="must">
+		<type type-name="Unsigned64"/>
+	</avp>
+	<avp name="Check-Balance-Result" code="422" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<type type-name="Enumerated"/>
+		<enum name="ENOUGH_CREDIT" code="0"/>
+		<enum name="NO_CREDIT" code="1"/>
+	</avp>
+	<avp name="Cost-Information" code="423" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<grouped>
+			<gavp name="Unit-Value"/>
+			<gavp name="Currency-Code"/>
+			<gavp name="Cost-Unit"/>
+		</grouped>
+	</avp>
+	<avp name="Cost-Unit" code="424" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="Currency-Code" code="425" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="Credit-Control" code="426" mandatory="must">
+		<type type-name="Enumerated"/>
+		<enum name="CREDIT_AUTHORIZATION" code="0"/>
+		<enum name="RE_AUTHORIZATION" code="1"/>
+	</avp>
+	<avp name="Credit-Control-Failure-Handling" code="427" mandatory="must">
+		<type type-name="Enumerated"/>
+		<enum name="TERMINATE" code="0"/>
+		<enum name="CONTINUE" code="1"/>
+		<enum name="RETRY_AND_TERMINATE" code="2"/>
+	</avp>
+	<avp name="Direct-Debiting-Failure-Handling" code="428" mandatory="must">
+		<type type-name="Enumerated"/>
+		<enum name="CONTINUE" code="1"/>
+		<enum name="TERMINATE_OR_BUFFER" code="0"/>
+	</avp>
+	<avp name="Exponent" code="429" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<type type-name="Integer32"/>
+	</avp>
+	<avp name="Final-Unit-Indication" code="430" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<grouped>
+			<gavp name="Final-Unit-Action"/>
+			<gavp name="Restriction-Filter-Rule"/>
+			<gavp name="Filter-Id"/>
+			<gavp name="Redirect-Server"/>
+		</grouped>
+	</avp>
+	<avp name="Granted-Service-Unit" code="431" mandatory="must">
+		<grouped>
+			<gavp name="Tariff-Time-Change"/>
+			<gavp name="CC-Time"/>
+			<gavp name="CC-Money"/>
+			<gavp name="CC-Total-Octets"/>
+			<gavp name="CC-Input-Octets"/>
+			<gavp name="CC-output-Octets"/>
+			<gavp name="CC-Service-Specific-Units"/>
+		</grouped>
+	</avp>
+	<avp name="Rating-Group" code="432" mandatory="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="Redirect-Address-Type" code="433" mandatory="must">
+		<type type-name="Enumerated"/>
+		<enum name="IPV6_ADDRESS" code="1"/>
+		<enum name="SIP_URI" code="3"/>
+		<enum name="URL" code="2"/>
+		<enum name="IPV4_ADDRESS" code="0"/>
+	</avp>
+	<avp name="Redirect-Server" code="434" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<grouped>
+			<gavp name="Redirect-Address-Type"/>
+			<gavp name="Redirect-Server-Address"/>
+		</grouped>
+	</avp>
+	<avp name="Redirect-Server-Address" code="435" mandatory="must">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="Requested-Action" code="436" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<type type-name="Unsigned32"/>
+		<enum name="DIRECT_DEBITING"  code="0"/>
+		<enum name="REFUND_ACCOUNT"   code="1"/>
+		<enum name="CHECK_BALANCE"    code="2"/>
+		<enum name="PRICE_ENQUIRY"    code="3"/>
+	</avp>
+	<avp name="Requested-Service-Unit" code="437" mandatory="must">
+		<grouped>
+			<gavp name="CC-Time"/>
+			<gavp name="CC-Money"/>
+			<gavp name="CC-Total-Octets"/>
+			<gavp name="CC-Input-Octets"/>
+			<gavp name="CC-output-Octets"/>
+			<gavp name="CC-Service-Specific-Units"/>
+		</grouped>
+	</avp>
+	<avp name="Restricted-Filter-Rule" code="438" mandatory="must">
+		<type type-name="IPFilterRule"/>
+	</avp>
+	<avp name="Service-Identifier" code="439" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="Service-Parameter-Info" code="440" mandatory="may" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<grouped>
+			<gavp name="Service-Parameter-Type"/>
+			<gavp name="Service-Parameter-Value"/>
+		</grouped>
+	</avp>
+	<avp name="Service-Parameter-Type" code="441" mandatory="may" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<type type-name="Unsigned32"/>
+		<!-- This field is vendor defined. -->
+	</avp>
+	<avp name="Service-Parameter-Value" code="442" mandatory="may" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="Subscription-Id" code="443" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<grouped>
+			<gavp name="Subscription-Id-Data"/>
+			<gavp name="Subscription-Id-Type"/>
+		</grouped>
+	</avp>
+	<avp name="Subscription-Id-Data" code="444" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="Unit-Value" code="445" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<grouped>
+			<gavp name="Value-Digits"/>
+			<gavp name="Exponent"/>
+		</grouped>
+	</avp>
+	<avp name="Used-Service-Unit" code="446" mandatory="must">
+		<grouped>
+			<gavp name="Tariff-Change-Usage"/>
+			<gavp name="CC-Time"/>
+			<gavp name="CC-Money"/>
+			<gavp name="CC-Total-Octets"/>
+			<gavp name="CC-Input-Octets"/>
+			<gavp name="CC-output-Octets"/>
+			<gavp name="CC-Service-Specific-Units"/>
+		</grouped>
+	</avp>
+	<avp name="Value-Digits" code="447" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<type type-name="Integer64"/>
+	</avp>
+	<avp name="Validity-Time" code="448" mandatory="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="Final-Unit-Action" code="449" mandatory="must">
+		<type type-name="Enumerated"/>
+		<enum name="TERMINATE" code="0"/>
+		<enum name="REDIRECT" code="1"/>
+		<enum name="RESTRICT_ACCESS" code="2"/>
+	</avp>
+	<avp name="Subscription-Id-Type" code="450" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<type type-name="Unsigned32"/>
+		<enum name="END_USER_E164"    code="0"/>
+		<enum name="END_USER_IMSI"    code="1"/>
+		<enum name="END_USER_SIP_URI" code="2"/>
+		<enum name="END_USER_NAI"     code="3"/>
+		<enum name="END_USER_PRIVATE" code="4"/>
+	</avp>
+	<avp name="Tariff-Time-Change" code="451" mandatory="must">
+		<type type-name="Time"/>
+	</avp>
+	<avp name="Tariff-Change-Usage" code="452" mandatory="must">
+		<type type-name="Enumerated"/>
+		<enum name="UNIT_AFTER_TARIFF_CHANGE" code="1"/>
+		<enum name="UNIT_INDETERMINATE" code="2"/>
+		<enum name="UNIT_BEFORE_TARIFF_CHANGE" code="0"/>
+	</avp>
+	<avp name="G-S-U-Pool-Identifier" code="453" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="CC-Unit-Type" code="454" mandatory="must">
+		<type type-name="Enumerated"/>
+		<enum name="TIME" code="0"/>
+		<enum name="MONEY" code="1"/>
+		<enum name="TOTAL-OCTETS" code="2"/>
+		<enum name="OUTPUT-OCTETS" code="4"/>
+		<enum name="INPUT-OCTETS" code="3"/>
+		<enum name="SERVICE-SPECIFIC-UNITS" code="5"/>
+	</avp>
+	<avp name="Multiple-Services-Indicator" code="455" mandatory="must">
+		<type type-name="Enumerated"/>
+		<enum name="MULTIPLE_SERVICES_NOT_SUPPORTED" code="0"/>
+		<enum name="MULTIPLE_SERVICES_SUPPORTED" code="1"/>
+	</avp>
+	<avp name="Multiple-Services-Credit-Control" code="456" mandatory="must">
+		<grouped>
+			<gavp name="Granted-Service-Unit"/>
+			<gavp name="Requested-Service-Unit"/>
+			<gavp name="Used-Service-Unit"/>
+			<gavp name="Tariff-Change-Usage"/>
+			<gavp name="Service-Identifier"/>
+			<gavp name="Rating-Group"/>
+			<gavp name="G-S-U-Pool-Reference"/>
+			<gavp name="Validity-Time"/>
+			<gavp name="Result-Code"/>
+			<gavp name="Final-Unit-Indication"/>
+		</grouped>
+	</avp>
+	<avp name="G-S-U-Pool-Reference" code="457" mandatory="must">
+		<grouped>
+			<gavp name="G-S-U-Pool-Identifier"/>
+			<gavp name="CC-Unit-Type"/>
+			<gavp name="Unit-Value"/>
+		</grouped>
+	</avp>
+	<avp name="User-Equipment-Info" code="458" mandatory="may">
+		<grouped>
+			<gavp name="User-Equipment-Info-Type"/>
+			<gavp name="User-Equipment-Info-Value"/>
+		</grouped>
+	</avp>
+	<avp name="User-Equipment-Info-Type" code="459" mandatory="may">
+		<type type-name="Enumerated"/>
+		<enum name="IMEISV" code="0"/>
+		<enum name="MAC" code="1"/>
+		<enum name="EUI64" code="2"/>
+		<enum name="MODIFIED_EUI64" code="3"/>
+	</avp>
+	<avp name="User-Equipment-Info-Value" code="460" mandatory="may">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="Service-Context-Id" code="461" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<type type-name="UTF8String"/>
+	</avp>
 
     <!--Flow-Description-->
     <avp name="Flow-Description" code="507" vendor-id="Cisco" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must">

--- a/dictionaries/dictionary.xml
+++ b/dictionaries/dictionary.xml
@@ -1646,7 +1646,7 @@
 			<enum name="ITU-T Rs" code="16777235"/>
 			<enum name="3GPP Rx" code="16777236"/>
 			<enum name="3GPP2 Ty" code="16777237"/>
-			<enum name="3GPP Gx 2" code="16777238"/>
+			<enum name="3GPP Gx" code="16777238"/>
 			<enum name="Juniper Cluster" code="16777239"/>
 			<enum name="Juniper Policy-Control-AAA" code="16777240"/>
 			<enum name="iptego USPI" code="16777241"/>
@@ -1778,7 +1778,7 @@
 			<enum name="ITU-T Rs" code="16777235"/>
 			<enum name="3GPP Rx" code="16777236"/>
 			<enum name="3GPP2 Ty" code="16777237"/>
-			<enum name="3GPP Gx 2" code="16777238"/>
+			<enum name="3GPP Gx" code="16777238"/>
 			<enum name="Juniper Cluster" code="16777239"/>
 			<enum name="Juniper Policy-Control-AAA" code="16777240"/>
 			<enum name="iptego USPI" code="16777241"/>

--- a/dictionaries/dictionary.xml
+++ b/dictionaries/dictionary.xml
@@ -1646,7 +1646,7 @@
 			<enum name="ITU-T Rs" code="16777235"/>
 			<enum name="3GPP Rx" code="16777236"/>
 			<enum name="3GPP2 Ty" code="16777237"/>
-			<enum name="3GPP Gx" code="16777238"/>
+			<enum name="3GPP Gx 2" code="16777238"/>
 			<enum name="Juniper Cluster" code="16777239"/>
 			<enum name="Juniper Policy-Control-AAA" code="16777240"/>
 			<enum name="iptego USPI" code="16777241"/>
@@ -1778,7 +1778,7 @@
 			<enum name="ITU-T Rs" code="16777235"/>
 			<enum name="3GPP Rx" code="16777236"/>
 			<enum name="3GPP2 Ty" code="16777237"/>
-			<enum name="3GPP Gx" code="16777238"/>
+			<enum name="3GPP Gx 2" code="16777238"/>
 			<enum name="Juniper Cluster" code="16777239"/>
 			<enum name="Juniper Policy-Control-AAA" code="16777240"/>
 			<enum name="iptego USPI" code="16777241"/>

--- a/lib/diameter-codec.js
+++ b/lib/diameter-codec.js
@@ -7,6 +7,7 @@ var diameterUtil = require('./diameter-util');
 
 var DIAMETER_MESSAGE_HEADER_LENGTH_IN_BYTES = 20;
 var DIAMETER_MESSAGE_AVP_HEADER_LENGTH_IN_BYTES = 8;
+var DIAMETER_MESSAGE_VENDOR_ID_LENGTH_IN_BYTES = 4;
 
 // Byte positions for header fields
 var DIAMETER_MESSAGE_HEADER_VERSION = 0;
@@ -294,13 +295,29 @@ var encodeAvp = function(avp, appId) {
         }
         avpDataBuffer = diameterTypes.encode(type, value);
     }
+
+    if(avpTag['vendor-id']) {
+        DIAMETER_MESSAGE_AVP_HEADER_LENGTH_IN_BYTES = 12;
+    }
+
+    //write AVP Code
     var avpHeaderBuffer = new Buffer(DIAMETER_MESSAGE_AVP_HEADER_LENGTH_IN_BYTES);
     avpHeaderBuffer.writeUInt32BE(_.parseInt(avpTag.code), DIAMETER_MESSAGE_AVP_CODE);
-    // TODO handle these flags
-    var flags = _.values([false, false, false]);
+
+    //write AVP Flags
+    // TODO handle these flags properly
+    var flags = _.values([(!!avpTag['vendor-id']), (!!avpTag['mandatory']), (!!avpTag['protected'])]);
     var flagsInt = getIntFromBits(_.flatten([flags, [false, false, false, false, false]]));
     avpHeaderBuffer.writeUInt8(flagsInt, DIAMETER_MESSAGE_AVP_FLAGS);
+    //write AVP length
     writeUInt24BE(avpHeaderBuffer, DIAMETER_MESSAGE_AVP_LENGTH, avpDataBuffer.length + avpHeaderBuffer.length);
+    if(avpTag['vendor-id']) {
+        var vendorCode = diameterDictionary.getVendorByVendorId(avpTag['vendor-id']).code;
+        var vendorIdBuffer = new Buffer(DIAMETER_MESSAGE_VENDOR_ID_LENGTH_IN_BYTES);
+        vendorIdBuffer.writeUInt32BE(_.parseInt(vendorCode), 0);
+        Buffer.concat([avpHeaderBuffer, vendorIdBuffer]);
+    }
+
     if (avpDataBuffer.length % 4 !== 0) {
         var filler = new Buffer(4 - avpDataBuffer.length % 4);
         filler.fill(0);

--- a/lib/diameter-codec.js
+++ b/lib/diameter-codec.js
@@ -122,7 +122,7 @@ exports.findCommand = function(commandName, applicationId) {
 exports.constructRequest = function(applicationName, commandName, sessionId) {
     var application = exports.findApplication(applicationName);
     var command = exports.findCommand(commandName, application.id);
-    
+
     var request = {
         header: {
             version: 1,
@@ -145,7 +145,7 @@ exports.constructRequest = function(applicationName, commandName, sessionId) {
     if (sessionId == null) {
         sessionId = diameterUtil.random32BitNumber();
     }
-    
+
     request.body.push(['Session-Id', sessionId.toString()]);
 
     return request;
@@ -172,8 +172,8 @@ exports.constructResponse = function(message) {
     };
 
     var sessionId = _.find(message.body, function(avp) {
-                return avp[0] === 'Session-Id';
-            });
+        return avp[0] === 'Session-Id';
+    });
     if (sessionId) {
         response.body.push(['Session-Id', sessionId[1]]);
     }
@@ -189,7 +189,7 @@ var decodeAvpHeader = function(buffer, start) {
         mandatory: getBit(flags, DIAMETER_MESSAGE_AVP_FLAG_MANDATORY)
     };
     avp.length = readUInt24BE(buffer, start + DIAMETER_MESSAGE_AVP_LENGTH);
-    
+
     return avp;
 };
 
@@ -250,12 +250,12 @@ var avpsToArrayForm = function(avps) {
 
 exports.decodeMessage = function(buffer) {
     var message = exports.decodeMessageHeader(buffer);
-    var avps = decodeAvps(buffer, DIAMETER_MESSAGE_HEADER_LENGTH_IN_BYTES, 
-        message.header.length, message.header.applicationId);
+    var avps = decodeAvps(buffer, DIAMETER_MESSAGE_HEADER_LENGTH_IN_BYTES,
+      message.header.length, message.header.applicationId);
     inflateMessageHeader(message);
     message.body = avpsToArrayForm(avps);
     message._timeProcessed = _.now();
-    return message;    
+    return message;
 };
 
 var encodeAvps = function(avps, appId) {
@@ -297,7 +297,10 @@ var encodeAvp = function(avp, appId) {
     }
 
     if(avpTag['vendor-id']) {
+        //4 extra bytes for vendor id
         DIAMETER_MESSAGE_AVP_HEADER_LENGTH_IN_BYTES = 12;
+    } else {
+        DIAMETER_MESSAGE_AVP_HEADER_LENGTH_IN_BYTES = 8;
     }
 
     //write AVP Code
@@ -309,15 +312,14 @@ var encodeAvp = function(avp, appId) {
     var flags = _.values([(!!avpTag['vendor-id']), (!!avpTag['mandatory']), (!!avpTag['protected'])]);
     var flagsInt = getIntFromBits(_.flatten([flags, [false, false, false, false, false]]));
     avpHeaderBuffer.writeUInt8(flagsInt, DIAMETER_MESSAGE_AVP_FLAGS);
-    //write AVP length
+
+    //Write AVP length
     writeUInt24BE(avpHeaderBuffer, DIAMETER_MESSAGE_AVP_LENGTH, avpDataBuffer.length + avpHeaderBuffer.length);
 
     if(avpTag['vendor-id']) {
         //write vendor-id
         var vendorCode = diameterDictionary.getVendorByVendorId(avpTag['vendor-id']).code;
-        var vendorIdBuffer = new Buffer(DIAMETER_MESSAGE_VENDOR_ID_LENGTH_IN_BYTES);
-        vendorIdBuffer.writeUInt32BE(_.parseInt(vendorCode), 0);
-        Buffer.concat([avpHeaderBuffer, vendorIdBuffer]);
+        avpHeaderBuffer.writeUInt32BE(_.parseInt(vendorCode), DIAMETER_MESSAGE_AVP_VENDOR_ID);
     }
 
     if (avpDataBuffer.length % 4 !== 0) {

--- a/lib/diameter-codec.js
+++ b/lib/diameter-codec.js
@@ -311,7 +311,9 @@ var encodeAvp = function(avp, appId) {
     avpHeaderBuffer.writeUInt8(flagsInt, DIAMETER_MESSAGE_AVP_FLAGS);
     //write AVP length
     writeUInt24BE(avpHeaderBuffer, DIAMETER_MESSAGE_AVP_LENGTH, avpDataBuffer.length + avpHeaderBuffer.length);
+
     if(avpTag['vendor-id']) {
+        //write vendor-id
         var vendorCode = diameterDictionary.getVendorByVendorId(avpTag['vendor-id']).code;
         var vendorIdBuffer = new Buffer(DIAMETER_MESSAGE_VENDOR_ID_LENGTH_IN_BYTES);
         vendorIdBuffer.writeUInt32BE(_.parseInt(vendorCode), 0);

--- a/lib/diameter-dictionary-parser.js
+++ b/lib/diameter-dictionary-parser.js
@@ -32,7 +32,8 @@ var collections = [
         'commands',
         'avps',
         'typedefns',
-        'config'
+        'config',
+        'vendors'
     ];
 
 var initDb = function() {
@@ -44,7 +45,7 @@ var initDb = function() {
 
 var parseDictionaryFiles = function(dictionaryFiles, fileStatsHash) {
     var deferred = Q.defer();
-    
+
     var saxStream = sax.createStream(false, {lowercase: true});
     saxStream.setMaxListeners(100);
 
@@ -120,6 +121,10 @@ var parseDictionaryFiles = function(dictionaryFiles, fileStatsHash) {
             }
             parent.gavps.push(node.attributes.name);
             dictionary.avps.update(parent);
+        },
+        vendor: function(node) {
+            currentTags.vendors = insertOrFind(dictionary.vendors, node.attributes,
+              { 'id': { '$eq': node.attributes['vendor-id'].toString() } });
         }
     };
 
@@ -134,7 +139,7 @@ var parseDictionaryFiles = function(dictionaryFiles, fileStatsHash) {
             tagHandler(node);
         }
     });
-    
+
     saxStream.on('closetag', function (tag) {
         currentTags[tag] = null;
     });
@@ -146,17 +151,17 @@ var parseDictionaryFiles = function(dictionaryFiles, fileStatsHash) {
         } else {
             dictionary.config.insert({
                 name: 'fileStatsHash',
-                value: fileStatsHash 
+                value: fileStatsHash
             });
             db.save(function() {
-                deferred.resolve(dictionary); 
+                deferred.resolve(dictionary);
             });
         }
     });
 
     fs.createReadStream(_.last(dictionaryFiles)).pipe(saxStream);
     dictionaryFiles = _.dropRight(dictionaryFiles);
-    
+
     return deferred.promise;
 };
 
@@ -211,7 +216,7 @@ exports.getDictionary = function() {
             var fileStatsHash = hashFileStats(fileStats);
 
             if (!fs.existsSync(dictionaryDbLocation)) {
-                parseDictionaryFiles(files, fileStatsHash).then(dictionaryDeferred.resolve, 
+                parseDictionaryFiles(files, fileStatsHash).then(dictionaryDeferred.resolve,
                         dictionaryDeferred.reject);
             } else {
                 db.loadDatabase({}, function() {
@@ -221,7 +226,7 @@ exports.getDictionary = function() {
                     if (isDbUpToDate(fileStatsHash)) {
                         dictionaryDeferred.resolve(dictionary);
                     } else {
-                        parseDictionaryFiles(files, fileStatsHash).then(dictionaryDeferred.resolve, 
+                        parseDictionaryFiles(files, fileStatsHash).then(dictionaryDeferred.resolve,
                             dictionaryDeferred.reject);
                     }
                 });

--- a/lib/diameter-dictionary.js
+++ b/lib/diameter-dictionary.js
@@ -33,6 +33,30 @@ exports.getApplicationByName = function(appName) {
     });
 };
 
+exports.getVendorByVendorId = function(vendorId) {
+    return dictionary.vendors.findOne({
+        'vendor-id': {
+            '$eq': vendorId.toString()
+        }
+    });
+};
+
+exports.getVendorByCode = function(vendorCode) {
+    return dictionary.vendors.findOne({
+        'code': {
+            '$eq': vendorCode.toString()
+        }
+    });
+};
+
+exports.getVendorByName = function(vendorName) {
+    return dictionary.vendors.findOne({
+        'name': {
+            '$eq': vendorName.toString()
+        }
+    });
+};
+
 var getCommandByAttribute = function(appId, value, attribute) {
     var attributeQuery = {};
     attributeQuery[attribute] = {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "diameter",
   "version": "0.4.0",
   "description": "Diameter base protocol implementation",
-  "author": "Robert Kovacevic <robert.kovacevic1@gmail.com>",
+  "author": {
+    "name": "Robert Kovacevic",
+    "email": "robert.kovacevic1@gmail.com"
+  },
   "license": "GPL-3.0",
   "main": "./lib/diameter",
   "repository": {
@@ -34,6 +37,21 @@
     "example-client": "node examples/diameter-client-example.js"
   },
   "keywords": [
-    "diameter", "protocol", "rfc6733", "server", "client"
-  ]
+    "diameter",
+    "protocol",
+    "rfc6733",
+    "server",
+    "client"
+  ],
+  "gitHead": "dc7c06899bd8b493e683c023b1be66f928ae1d43",
+  "readme": "# node-diameter\r\n\r\n[![Code Climate](https://codeclimate.com/github/node-diameter/node-diameter/badges/gpa.svg)](https://codeclimate.com/github/node-diameter/node-diameter)\r\n\r\nnode-diameter is node.js implementation of Base Diameter protocol. It is intended for testing existing diameter apps. \r\n\r\n## Usage\r\n\r\nCheck client and server in 'examples' directory. \r\n\r\nTo see it in action:\r\n\r\n````bash\r\n$ npm install\r\n````\r\n\r\n### Start server:\r\n````bash\r\n$ npm run-script example-server\r\n````\r\n\r\n### Start client:\r\n````bash\r\n$ npm run-script example-client\r\n````\r\n\r\n## Dictionary\r\n\r\nnode-diameter will use dictionaries you put in 'dictionaries' directory, in Wireshark xml format. On first launch, it will parse XML files, and store the dictionary in 'dictionary.json', in LokiJS database. \r\n\r\n",
+  "readmeFilename": "README.md",
+  "bugs": {
+    "url": "https://github.com/node-diameter/node-diameter/issues"
+  },
+  "homepage": "https://github.com/node-diameter/node-diameter#readme",
+  "_id": "diameter@0.4.0",
+  "_shasum": "035e63fbdd9b58b00e57a2c05f4d47c539a97a3e",
+  "_from": "git+https://github.com/freundschaft/node-diameter.git",
+  "_resolved": "git+https://github.com/freundschaft/node-diameter.git#dc7c06899bd8b493e683c023b1be66f928ae1d43"
 }


### PR DESCRIPTION
I have implemented the vendor id field for avp headers and it looks good, have verified it in traces. there is some adjustment that can be done to make the code look nicer, which I will supply at a later point.

You can ignore the changes in the cisco.xml file, I needed them for my project but they are not strictly important for the node-diameter library, but I dont know how to exclude them from the pull request.

Cheers
