### PR TITLE
fix(createConnection): allow all options for net.createConnection

### DIFF
--- a/lib/diameter.js
+++ b/lib/diameter.js
@@ -16,7 +16,8 @@ exports.createServer = function(options, connectionListener) {
 };
 
 exports.createConnection = function(options, connectionListener) {
-    var socket = net.createConnection(options.port, options.host || 'localhost', connectionListener);
+    options.host = options.host || 'localhost';
+    var socket = net.createConnection(options, connectionListener);
     var session = new DiameterSession(options, socket);
     socket.diameterSession = session;
     return socket;


### PR DESCRIPTION
this is especially helpful when you want to tell to connect with specific setting, for instance local port ...
