### PR TITLE
Read/write 64-bit integers in big-endian (high 32, low 32)

### DIFF
--- a/lib/diameter-types.js
+++ b/lib/diameter-types.js
@@ -39,11 +39,11 @@ var types = {
         encode: function(value) {
             var buffer = new Buffer(8, 'hex');
             if (value instanceof Long) {
-                buffer.writeUInt32BE(value.high, 4);
-                buffer.writeUInt32BE(value.low, 0);
+                buffer.writeUInt32BE(value.high, 0);
+                buffer.writeUInt32BE(value.low, 4);
             } else {
-                buffer.writeUInt32BE(0, 4);
-                buffer.writeUInt32BE(value, 0);
+                buffer.writeUInt32BE(0, 0);
+                buffer.writeUInt32BE(value, 4);
             }
             return buffer;
         },
@@ -55,11 +55,11 @@ var types = {
         encode: function(value) {
             var buffer = new Buffer(8, 'hex');
             if (value instanceof Long) {
-                buffer.writeInt32BE(value.high, 4);
-                buffer.writeInt32BE(value.low, 0);
+                buffer.writeInt32BE(value.high, 0);
+                buffer.writeInt32BE(value.low, 4);
             } else {
-                buffer.writeInt32BE(0, 4);
-                buffer.writeInt32BE(value, 0);
+                buffer.writeInt32BE(0, 0);
+                buffer.writeInt32BE(value, 4);
             }
             return buffer;
         },


### PR DESCRIPTION
The high 32 bits come first, followed by low 32 bits. Verified with Seagull that a 64-bit value is transmitted properly.
