### PR TITLE
Catch data handling error and emit as socket error

### DIFF
--- a/lib/diameter-session.js
+++ b/lib/diameter-session.js
@@ -31,51 +31,55 @@ function DiameterSession(options, socket) {
     var buffer = new Buffer(0, 'hex');
 
     self.socket.on('data', function(data) {
-        buffer = Buffer.concat([buffer, new Buffer(data, 'hex')]);
+        try {
+            buffer = Buffer.concat([buffer, new Buffer(data, 'hex')]);
 
-        // If we collected header
-        if (buffer.length >= DIAMETER_MESSAGE_HEADER_LENGTH_IN_BYTES) {
-            var messageLength = diameterCodec.decodeMessageHeader(buffer).header.length;
+            // If we collected header
+            if (buffer.length >= DIAMETER_MESSAGE_HEADER_LENGTH_IN_BYTES) {
+                var messageLength = diameterCodec.decodeMessageHeader(buffer).header.length;
 
-            // If we collected the entire message
-            if (buffer.length >= messageLength) {
-                var message = diameterCodec.decodeMessage(buffer);
+                // If we collected the entire message
+                if (buffer.length >= messageLength) {
+                    var message = diameterCodec.decodeMessage(buffer);
 
-                if (message.header.flags.request) {
-                    if (self.sessionId === undefined) {
-                        self.sessionId = getSessionId(message);
-                    }
-                    var response = diameterCodec.constructResponse(message);
+                    if (message.header.flags.request) {
+                        if (self.sessionId === undefined) {
+                            self.sessionId = getSessionId(message);
+                        }
+                        var response = diameterCodec.constructResponse(message);
 
-                    if (_.isFunction(self.options.beforeAnyMessage)) {
-                        self.options.beforeAnyMessage(message);
-                    }
+                        if (_.isFunction(self.options.beforeAnyMessage)) {
+                            self.options.beforeAnyMessage(message);
+                        }
 
-                    self.socket.emit('diameterMessage', {
-                        message: message,
-                        response: response,
-                        callback: function(response) {
-                            if (_.isFunction(self.options.afterAnyMessage)) {
-                                self.options.afterAnyMessage(response);
+                        self.socket.emit('diameterMessage', {
+                            message: message,
+                            response: response,
+                            callback: function(response) {
+                                if (_.isFunction(self.options.afterAnyMessage)) {
+                                    self.options.afterAnyMessage(response);
+                                }
+                                var responseBuffer = diameterCodec.encodeMessage(response);
+                                self.socket.write(responseBuffer);
                             }
-                            var responseBuffer = diameterCodec.encodeMessage(response);
-                            self.socket.write(responseBuffer);
-                        }
-                    });
-                } else {
-                    var pendingRequest = self.pendingRequests[message.hopByHopId];
-                    if (pendingRequest != null) {
-                        if (_.isFunction(self.options.afterAnyMessage)) {
-                            self.options.afterAnyMessage(message);
-                        }
-                        self.pendingRequests[message.hopByHopId] = undefined;
-                        pendingRequest.deferred.resolve(message);
+                        });
                     } else {
-                        // handle this
+                        var pendingRequest = self.pendingRequests[message.hopByHopId];
+                        if (pendingRequest != null) {
+                            if (_.isFunction(self.options.afterAnyMessage)) {
+                                self.options.afterAnyMessage(message);
+                            }
+                            self.pendingRequests[message.hopByHopId] = undefined;
+                            pendingRequest.deferred.resolve(message);
+                        } else {
+                            // handle this
+                        }
                     }
+                    buffer = buffer.slice(messageLength);
                 }
-                buffer = buffer.slice(messageLength);
             }
+        } catch (err) {
+            self.socket.emit('error', err);
         }
     });
 


### PR DESCRIPTION
Uncaught exceptions in socket data event handler cause the process to exit. Exceptions can occur either in diameterMessage handlers or in diameter-session.js itself (if an unknown command/AVP etc. that's not in the stock dictionary is encountered).
