### PR TITLE
Delete pending request key instead of setting to undefined

### DIFF
--- a/lib/diameter-session.js
+++ b/lib/diameter-session.js
@@ -69,7 +69,7 @@ function DiameterSession(options, socket) {
                             if (_.isFunction(self.options.afterAnyMessage)) {
                                 self.options.afterAnyMessage(message);
                             }
-                            self.pendingRequests[message.hopByHopId] = undefined;
+                            delete self.pendingRequests[message.hopByHopId];
                             pendingRequest.deferred.resolve(message);
                         } else {
                             // handle this
@@ -110,7 +110,7 @@ function DiameterSession(options, socket) {
         };
         return promise;
     };
-    
+
     self.end = function() {
         socket.end();
     };


### PR DESCRIPTION
When just set to `undefined` the properties will just accumulate on the `pendingRequests` object.