### PR TITLE
hopByHopId is a property of header

### DIFF
--- a/lib/diameter-connection.js
+++ b/lib/diameter-connection.js
@@ -61,12 +61,12 @@ function DiameterConnection(options, socket) {
                             }
                         });
                     } else {
-                        var pendingRequest = self.pendingRequests[message.hopByHopId];
+                        var pendingRequest = self.pendingRequests[message.header.hopByHopId];
                         if (pendingRequest != null) {
                             if (_.isFunction(self.options.afterAnyMessage)) {
                                 self.options.afterAnyMessage(message);
                             }
-                            delete self.pendingRequests[message.hopByHopId];
+                            delete self.pendingRequests[message.header.hopByHopId];
                             pendingRequest.deferred.resolve(message);
                         } else {
                             // handle this
@@ -101,7 +101,7 @@ function DiameterConnection(options, socket) {
         var requestBuffer = diameterCodec.encodeMessage(request);
         this.socket.write(requestBuffer);
         var promise = deferred.promise.timeout(timeout, 'Request timed out, no response was received in ' + timeout + 'ms');
-        this.pendingRequests[request.hopByHopId] = {
+        this.pendingRequests[request.header.hopByHopId] = {
             'request': request,
             'deferred': deferred
         };


### PR DESCRIPTION
`request.hopByHopId` is undefined. The reason the examples work is, a single request is being tracked through the key `"undefined"` and a match is found.