### PR TITLE
OCS-220:  

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -19416,7 +19416,7 @@
             "code": 455,
             "name": "Multiple-Services-Indicator",
             "vendorId": 0,
-            "type": "Integer32",
+            "type": "Unsigned32",
             "flags": {
                 "mandatory": true,
                 "protected": false,


### PR DESCRIPTION
Our OCS sends this as an Unsigned32, dictionary.json is calling for an Integer32.  Need to verify connect.