### PR TITLE
Don't write response synchronously

### DIFF
--- a/lib/diameter-connection.js
+++ b/lib/diameter-connection.js
@@ -57,7 +57,9 @@ function DiameterConnection(options, socket) {
                                     self.options.afterAnyMessage(response);
                                 }
                                 var responseBuffer = diameterCodec.encodeMessage(response);
-                                self.socket.write(responseBuffer);
+                                setImmediate(function() {
+                                    self.socket.write(responseBuffer);
+                                });
                             }
                         });
                     } else {


### PR DESCRIPTION
In my development environment, I've set my Diameter server to act both as an initiator and a responder to connect to itself so that I can test my device watchdog implementation. Even though there's barely any load on the server except for a DWR/DWA exchange every 3 seconds, receipt of DWA tends to randomly fail after a while.

Note that this is all happening on the single thread of a single Node.js process, so one might argue that it's not a realistic scenario that should be worried about, but I think node-diameter should be able to robustly handle loopback connections.

I added a lot of log statements to both my code and within node-diameter's diameter-connection.js to get a sense of the timing of events, and also did some reading into Node.js's event loop internals, but I wasn't able to pinpoint exactly the condition that triggers the missed receipt of DWA.

However, through some experimentation and intuition, I was able to get around the problem by making the response sending asynchronous by wrapping the `socket.write` call inside a `setImmediate`. The fact that both the request receipt and the response sending happen entirely synchronously seems to be the culprit. While it is possible to let application writers call the response callback asynchronously, I thought it would be better to make node-diameter's sending of the response asynchronous itself.

I don't see any immediate negative consequences of doing so, and it indeed solved the problem I was having. While I still would love to get an understanding of exactly what is going on with the event processing phases in this particular case, I think we could go ahead with this fix without fully getting down to the bottom of what the issue is.

I also think the synchronous response sending might have something to do with some of the other performance/robustness issues that were mentioned in some of the open issues. 