### PR TITLE
Util find avp by path

### DIFF
--- a/lib/diameter-util.js
+++ b/lib/diameter-util.js
@@ -61,3 +61,53 @@ exports.messageToColoredString = function(message) {
     messageString += chalk.gray(_.repeat('-', 80));
     return messageString;
 };
+
+var getPathElements = function(path) {
+    var pathElements = [];
+    if (path === undefined || path === null) return pathElements;
+    return path.split('.').map(function(pathElement) {
+        if (pathElement.endsWith(']')) {
+            var parts = pathElement.split('[');
+            var index = parseInt(parts[1].substring(
+                0,
+                parts[1].length - 1
+            ), 10);
+            return {
+                name: parts[0],
+                index: index
+            }
+        } else {
+            return {
+                name: pathElement
+            }
+        }
+    });
+};
+
+exports.getAvpValue = function(message, path) {
+    var pathElements = getPathElements(path);
+    if (pathElements.length === 0) return undefined;
+    var firstAvpName = pathElements[0].name;
+    var avps = _.select(message, avp => {
+        return avp[0] === firstAvpName
+    });
+
+    if (avps.length > 0) {
+        if (avps.length === 1 && pathElements[0].index === undefined) {
+            if (pathElements.length === 1) {
+                return avps[0][1];
+            } else {
+                return exports.getAvpValue(avps[0][1], path.substring(path.indexOf('.') + 1, path.length));        
+            }
+        } else if (pathElements[0].index !== undefined) {
+            if (pathElements.length === 1) {
+                return avps[pathElements[0].index][1];
+            } else {
+                return exports.getAvpValue(avps[pathElements[0].index][1], path.substring(path.indexOf('.') + 1, path.length));        
+            }
+        } else {
+            throw new Error('Can\'t resolve path, multiple AVPs found with name \'' + firstAvpName + '\'');
+        }
+    }
+    return undefined;
+};

--- a/lib/diameter-util.js
+++ b/lib/diameter-util.js
@@ -66,15 +66,12 @@ var getPathElements = function(path) {
     var pathElements = [];
     if (path === undefined || path === null) return pathElements;
     return path.split('.').map(function(pathElement) {
-        if (pathElement.indexOf(']') > 0) {
-            var parts = pathElement.split('[');
-            var index = parseInt(parts[1].substring(
-                0,
-                parts[1].length - 1
-            ), 10);
+        // tests if the element has an array index, e.g. Some-Avp[1]
+        if (/.*\[[0-9]*\]$/.test(pathElement)) {
+            var parts = /(.*)\[([0-9]*)\]$/g.exec(pathElement);
             return {
-                name: parts[0],
-                index: index
+                name: parts[1],
+                index: parts[2]
             }
         } else {
             return {

--- a/lib/diameter-util.js
+++ b/lib/diameter-util.js
@@ -63,12 +63,10 @@ exports.messageToColoredString = function(message) {
 };
 
 var getPathElements = function(path) {
-    console.log(path + ' -----------')
     var pathElements = [];
     if (path === undefined || path === null) return pathElements;
     return path.split('.').map(function(pathElement) {
-        console.log(JSON.stringify(pathElement));
-        if (pathElement.endsWith(']')) {
+        if (pathElement.indexOf(']') > 0) {
             var parts = pathElement.split('[');
             var index = parseInt(parts[1].substring(
                 0,

--- a/lib/diameter-util.js
+++ b/lib/diameter-util.js
@@ -89,7 +89,7 @@ exports.getAvpValue = function(message, path) {
     var pathElements = getPathElements(path);
     if (pathElements.length === 0) return undefined;
     var firstAvpName = pathElements[0].name;
-    var avps = _.select(message, function(avp) {
+    var avps = _.filter(message, function(avp) {
         return avp[0] === firstAvpName
     });
 

--- a/lib/diameter-util.js
+++ b/lib/diameter-util.js
@@ -66,9 +66,8 @@ var getPathElements = function(path) {
     var pathElements = [];
     if (path === undefined || path === null) return pathElements;
     return path.split('.').map(function(pathElement) {
-        // tests if the element has an array index, e.g. Some-Avp[1]
-        if (/.*\[[0-9]*\]$/.test(pathElement)) {
-            var parts = /(.*)\[([0-9]*)\]$/g.exec(pathElement);
+        var parts = /([^[]+)\[(\d)\]$/.exec(pathElement);
+        if (parts !== null) { // element has an array index, e.g. Some-Avp[1]
             return {
                 name: parts[1],
                 index: parts[2]

--- a/lib/diameter-util.js
+++ b/lib/diameter-util.js
@@ -78,6 +78,7 @@ var getPathElements = function(path) {
             }
         } else {
             return {
+                index: 0,
                 name: pathElement
             }
         }
@@ -93,20 +94,17 @@ exports.getAvpValue = function(message, path) {
     });
 
     if (avps.length > 0) {
-        if (avps.length === 1 && pathElements[0].index === undefined) {
-            if (pathElements.length === 1) {
-                return avps[0][1];
-            } else {
-                return exports.getAvpValue(avps[0][1], path.substring(path.indexOf('.') + 1, path.length));        
-            }
-        } else if (pathElements[0].index !== undefined) {
-            if (pathElements.length === 1) {
-                return avps[pathElements[0].index][1];
-            } else {
-                return exports.getAvpValue(avps[pathElements[0].index][1], path.substring(path.indexOf('.') + 1, path.length));        
-            }
-        } else {
+        if (pathElements[0].index === 0 && avps.length > 1) {
             throw new Error('Can\'t resolve path, multiple AVPs found with name \'' + firstAvpName + '\'');
+        }
+        if (pathElements[0].index >= avps.length) {
+            throw new Error('Can\'t resolve path, index for \'' + firstAvpName + '\' is out of bounds');
+        }
+        
+        if (pathElements.length === 1) {
+            return avps[pathElements[0].index][1];
+        } else {
+            return exports.getAvpValue(avps[pathElements[0].index][1], path.substring(path.indexOf('.') + 1, path.length));        
         }
     }
     return undefined;

--- a/lib/diameter-util.js
+++ b/lib/diameter-util.js
@@ -89,7 +89,7 @@ exports.getAvpValue = function(message, path) {
     var pathElements = getPathElements(path);
     if (pathElements.length === 0) return undefined;
     var firstAvpName = pathElements[0].name;
-    var avps = _.select(message, avp => {
+    var avps = _.select(message, function(avp) {
         return avp[0] === firstAvpName
     });
 

--- a/lib/diameter-util.js
+++ b/lib/diameter-util.js
@@ -63,9 +63,11 @@ exports.messageToColoredString = function(message) {
 };
 
 var getPathElements = function(path) {
+    console.log(path + ' -----------')
     var pathElements = [];
     if (path === undefined || path === null) return pathElements;
     return path.split('.').map(function(pathElement) {
+        console.log(JSON.stringify(pathElement));
         if (pathElement.endsWith(']')) {
             var parts = pathElement.split('[');
             var index = parseInt(parts[1].substring(

--- a/lib/diameter.js
+++ b/lib/diameter.js
@@ -28,3 +28,5 @@ exports.messageToColoredString = diameterUtil.messageToColoredString;
 exports.logMessage = function(message) {
     console.log(exports.messageToColoredString(message));
 };
+
+exports.getAvpValue = diameterUtil.getAvpValue;

--- a/test/diameter-util-spec.js
+++ b/test/diameter-util-spec.js
@@ -1,8 +1,101 @@
 var util = require('../lib/diameter-util');
+var _ = require('lodash');
 
 describe('diameter-util', function() {
 
     it('generates random number', function() {
         expect(util.random32BitNumber()).toBeGreaterThan(0);
+    });
+
+    it('gets AVP value from a diameter message', function() {
+        this.addMatchers({
+            toDeepEqual: function(expected) {
+                return _.isEqual(this.actual, expected);
+            }
+        });
+        
+        var exampleMessage = [
+            ['Result-Code', 2001], // You can also define enum values by their integer codes
+            [264, 'test.com'], // or AVP names, this is 'Origin-Host'
+            ['Origin-Realm', 'com'],
+            ['Auth-Application-Id', 'Diameter Credit Control'],
+            ['CC-Request-Type', 'INITIAL_REQUEST'],
+            ['CC-Request-Number', 0],
+            ['Multiple-Services-Credit-Control', [
+                ['Granted-Service-Unit', [
+                    ['CC-Time', 123],
+                    ['CC-Money', [
+                        ['Unit-Value', [
+                            ['Value-Digits', 123],
+                            ['Exponent', 1]
+                        ]],
+                        ['Currency-Code', 1]
+                    ]],
+                    ['CC-Total-Octets', 123],
+                    ['CC-Input-Octets', 123],
+                    ['CC-Output-Octets', 123]
+                ]],
+                ['Requested-Service-Unit', [
+                    ['CC-Time', 123],
+                    ['CC-Money', [
+                        ['Unit-Value', [
+                            ['Value-Digits', 123],
+                            ['Exponent', 1]
+                        ]],
+                        ['Currency-Code', 1]
+                    ]],
+                    ['CC-Total-Octets', 123],
+                    ['CC-Input-Octets', 123],
+                    ['CC-Output-Octets', 123]
+                ]],
+                ['Requested-Service-Unit', [
+                    ['CC-Time', 124],
+                    ['CC-Money', [
+                        ['Unit-Value', [
+                            ['Value-Digits', 123],
+                            ['Exponent', 1]
+                        ]],
+                        ['Currency-Code', 1]
+                    ]],
+                    ['CC-Total-Octets', 123],
+                    ['CC-Input-Octets', 123],
+                    ['CC-Output-Octets', 123]
+                ]]
+            ]]
+        ];
+
+        expect(util.getAvpValue(exampleMessage, '....')).toBe(undefined)
+        expect(util.getAvpValue(exampleMessage, 'Origin-Realm')).toBe('com')
+        expect(util.getAvpValue(exampleMessage, 'Not-Present')).toBe(undefined)
+        expect(util.getAvpValue(exampleMessage, 'Result-Code')).toBe(2001)
+        expect(util.getAvpValue(exampleMessage, 
+            'Multiple-Services-Credit-Control.Granted-Service-Unit.CC-Time'))
+            .toBe(123);
+        expect(util.getAvpValue(exampleMessage, 
+            'Multiple-Services-Credit-Control.Granted-Service-Unit.Missing'))
+            .toBe(undefined);
+        expect(util.getAvpValue(exampleMessage, 
+            'Multiple-Services-Credit-Control.Requested-Service-Unit[1].CC-Time'))
+            .toBe(124);
+        expect(function() {
+                util.getAvpValue(exampleMessage, 
+                'Multiple-Services-Credit-Control.Requested-Service-Unit.CC-Time');
+            })
+            .toThrow(new Error('Can\'t resolve path, multiple AVPs found with name \'Requested-Service-Unit\''));
+        expect(util.getAvpValue(exampleMessage, 
+            'Multiple-Services-Credit-Control.Requested-Service-Unit[1]'))
+            .toDeepEqual([
+                ['CC-Time', 124],
+                ['CC-Money', [
+                    ['Unit-Value', [
+                        ['Value-Digits', 123],
+                        ['Exponent', 1]
+                    ]],
+                    ['Currency-Code', 1]
+                ]],
+                ['CC-Total-Octets', 123],
+                ['CC-Input-Octets', 123],
+                ['CC-Output-Octets', 123]
+            ]);
     });
 });

--- a/test/diameter-util-spec.js
+++ b/test/diameter-util-spec.js
@@ -64,10 +64,14 @@ describe('diameter-util', function() {
             ]]
         ];
 
-        expect(util.getAvpValue(exampleMessage, '....')).toBe(undefined)
-        expect(util.getAvpValue(exampleMessage, 'Origin-Realm')).toBe('com')
-        expect(util.getAvpValue(exampleMessage, 'Not-Present')).toBe(undefined)
-        expect(util.getAvpValue(exampleMessage, 'Result-Code')).toBe(2001)
+        expect(util.getAvpValue(exampleMessage, '....')).toBe(undefined);
+        expect(util.getAvpValue(exampleMessage, 'Origin-Realm')).toBe('com');
+        expect(function() {
+            util.getAvpValue(exampleMessage, 'Origin-Realm[1]');
+        })
+        .toThrow(new Error('Can\'t resolve path, index for \'Origin-Realm\' is out of bounds'));
+        expect(util.getAvpValue(exampleMessage, 'Not-Present')).toBe(undefined);
+        expect(util.getAvpValue(exampleMessage, 'Result-Code')).toBe(2001);
         expect(util.getAvpValue(exampleMessage, 
             'Multiple-Services-Credit-Control.Granted-Service-Unit.CC-Time'))
             .toBe(123);


### PR DESCRIPTION
Adds a utility function to return AVP value, for a path like: 

> Multiple-Services-Credit-Control.Requested-Service-Unit[1].CC-Time

So, you separate path levels with '.', and if there are multiple AVPs with same name, you select like an array, with [].

For keys that don't exist, you get undefined (this is to mimic how normal js objects work). 

If you try to access index that doesn't exist, or there are multiple AVPs with the same name, but you don't provide an index, you get an error. I wanted to have it fail fast, in case there is ambiguity, because I worked with a framework that would just assume you want the first one, if there were multiple with the same name, and it was an endless source of bugs. 

@atesgoral have a look if you have some time, let me know if you have any suggestions. Everyone else too, of course :)

Btw, for everyone else, before using this, you should look at @atesgoral 's lib:
https://github.com/atesgoral/diameter-avp-object