### PR TITLE
Add support for AppId type

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -4286,7 +4286,7 @@
             "code": 258,
             "name": "Auth-Application-Id",
             "vendorId": 0,
-            "type": "Unsigned32",
+            "type": "AppId",
             "flags": {
                 "mandatory": true,
                 "protected": false,
@@ -4298,7 +4298,7 @@
             "code": 259,
             "name": "Acct-Application-Id",
             "vendorId": 0,
-            "type": "Unsigned32",
+            "type": "AppId",
             "flags": {
                 "mandatory": true,
                 "protected": false,

--- a/lib/diameter-codec.js
+++ b/lib/diameter-codec.js
@@ -215,7 +215,13 @@ var decodeAvp = function(buffer, start, appId) {
         avp.avps = decodeAvps(avp.dataRaw, 0, avp.dataRaw.length, appId);
     } else {
         avp.data = diameterTypes.decode(avpTag.type, avp.dataRaw);
-        if (avpTag.enums) {
+        if (avpTag.type === 'AppId') {
+            var application = dictionary.getApplicationById(avp.data);
+            if (application == null) {
+                throw new Error('Can\'t find application with ID ' + avp.data);
+            }
+            avp.data = application.name;
+        } else if (avpTag.enums) {
             var enumValue = _.find(avpTag.enums, {
                 code: avp.data
             });
@@ -307,7 +313,7 @@ var encodeAvp = function(avp, appId) {
                 enumCode = dictionary.getApplicationById(value);
             }
             if (enumCode == null) {
-                throw new Error('Invalid enum value ' + value + ' for ' + avpTag.name);
+                throw new Error('Invalid application ID value ' + value + ' for ' + avpTag.name);
             }
             value = enumCode.code;
         }
@@ -360,3 +366,4 @@ exports.encodeMessage = function(message) {
 };
 
 exports.encodeAvp = encodeAvp;
+exports.decodeAvp = decodeAvp;

--- a/lib/diameter-codec.js
+++ b/lib/diameter-codec.js
@@ -299,6 +299,17 @@ var encodeAvp = function(avp, appId) {
                 throw new Error('Invalid enum value ' + value + ' for ' + avpTag.name);
             }
             value = enumCode.code;
+        } else if (avpTag.type === 'AppId') {
+            var enumCode;
+            if (!_.isNumber(value)) {
+                enumCode = dictionary.getApplicationByName(value);
+            } else {
+                enumCode = dictionary.getApplicationById(value);
+            }
+            if (enumCode == null) {
+                throw new Error('Invalid enum value ' + value + ' for ' + avpTag.name);
+            }
+            value = enumCode.code;
         }
         avpDataBuffer = diameterTypes.encode(avpTag.type, value);
     }
@@ -347,3 +358,5 @@ exports.encodeMessage = function(message) {
     writeUInt24BE(buffer, DIAMETER_MESSAGE_HEADER_LENGTH, buffer.length);
     return buffer;
 };
+
+exports.encodeAvp = encodeAvp;

--- a/lib/diameter-types.js
+++ b/lib/diameter-types.js
@@ -122,8 +122,12 @@ var types = {
     }
 };
 
+var aliases = {
+    'AppId': 'Unsigned32'
+};
+
 var getType = function(type) {
-    var handler = types[type];
+    var handler = types[aliases[type] || type];
     if (handler == null) {
         throw new Error('No handler for type: ' + type);
     }

--- a/test/diameter-codec-spec.js
+++ b/test/diameter-codec-spec.js
@@ -2,9 +2,31 @@ var codec = require('../lib/diameter-codec');
 
 describe('diameter-codec', function() {
 
-    it('encodes message', function() {
+    describe('enodeAvp', function() {
 
+        it('encodes string key and string value', function() {
+            var avp = ['Result-Code', 'DIAMETER_SUCCESS'];
+            expect(codec.encodeAvp(avp).toString('hex')).toBe('0000010c4000000c000007d1');
+        });
 
-        //expect(util.random32BitNumber()).toBeGreaterThan(0);
+        it('encodes numeric key and string value', function() {
+            var avp = [268, 'DIAMETER_SUCCESS'];
+            expect(codec.encodeAvp(avp).toString('hex')).toBe('0000010c4000000c000007d1');
+        });
+
+        it('encodes numeric key and numeric value', function() {
+            var avp = [268, 2001];
+            expect(codec.encodeAvp(avp).toString('hex')).toBe('0000010c4000000c000007d1');
+        });
+
+        it('encodes string key and string value that is an application name', function() {
+            var avp = ['Auth-Application-Id', 'Diameter Credit Control Application'];
+            expect(codec.encodeAvp(avp).toString('hex')).toBe('000001024000000c00000004');
+        });
+
+        it('encodes string key and string value that is an application code', function() {
+            var avp = ['Auth-Application-Id', 4];
+            expect(codec.encodeAvp(avp).toString('hex')).toBe('000001024000000c00000004');
+        });
     });
 });

--- a/test/diameter-codec-spec.js
+++ b/test/diameter-codec-spec.js
@@ -32,7 +32,7 @@ describe('diameter-codec', function() {
     describe('decodeAvp', function() {
 
         it('decodes application ID code as a string', function() {
-            var buffer = Buffer.from('000001024000000c00000004', 'hex');
+            var buffer = new Buffer('000001024000000c00000004', 'hex');
             var decoded = codec.decodeAvp(buffer, 0);
             expect(decoded.code).toBe('Auth-Application-Id');
             expect(decoded.data).toBe('Diameter Credit Control Application');

--- a/test/diameter-codec-spec.js
+++ b/test/diameter-codec-spec.js
@@ -19,14 +19,23 @@ describe('diameter-codec', function() {
             expect(codec.encodeAvp(avp).toString('hex')).toBe('0000010c4000000c000007d1');
         });
 
-        it('encodes string key and string value that is an application name', function() {
+        it('encodes string key and string value that is an application ID name', function() {
             var avp = ['Auth-Application-Id', 'Diameter Credit Control Application'];
             expect(codec.encodeAvp(avp).toString('hex')).toBe('000001024000000c00000004');
         });
 
-        it('encodes string key and string value that is an application code', function() {
+        it('encodes string key and string value that is an application ID code', function() {
             var avp = ['Auth-Application-Id', 4];
             expect(codec.encodeAvp(avp).toString('hex')).toBe('000001024000000c00000004');
+        });
+    });
+    describe('decodeAvp', function() {
+
+        it('decodes application ID code as a string', function() {
+            var buffer = Buffer.from('000001024000000c00000004', 'hex');
+            var decoded = codec.decodeAvp(buffer, 0);
+            expect(decoded.code).toBe('Auth-Application-Id');
+            expect(decoded.data).toBe('Diameter Credit Control Application');
         });
     });
 });

--- a/test/diameter-codec-spec.js
+++ b/test/diameter-codec-spec.js
@@ -2,7 +2,7 @@ var codec = require('../lib/diameter-codec');
 
 describe('diameter-codec', function() {
 
-    describe('enodeAvp', function() {
+    describe('encodeAvp', function() {
 
         it('encodes string key and string value', function() {
             var avp = ['Result-Code', 'DIAMETER_SUCCESS'];


### PR DESCRIPTION
The Wireshark dictionary has gone through a major overhaul and they've removed all enums from AVPs that describe application IDs. We need to store these AVPs as of type AppId and do the lookup from the applications in the dictionary.