### PR TITLE
Enable usage of custom dictionaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ $ npm run-script example-server
 $ npm run-script example-client
 ````
 
+## Using custom diameter dictionaries
+
+To use your own diameter dictionary, set the 'DIAMETER_DICTIONARY' environment variable to path of the json file containing your dictionary, or name of node module that provides it. See 'node-diameter-dictionary' module for json file format, and how to create a node module that provides a dictionary. 
+Note: this module has a dependency on 'node-diameter-dictionary' module, so if you are using your own dictionary, you can optionaly remove the 'node-diameter-dictionary' dependency when doing the npm shrinkwrap of your application. 
+
 ## Complementary library
 
 Makes it easier to work with diameter messages, by converting the arrays to objects:

--- a/lib/diameter-dictionary.js
+++ b/lib/diameter-dictionary.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var _ = require('lodash');
-var dictionary = require('diameter-dictionary');
+var dictionary = require(process.env.DIAMETER_DICTIONARY || 'diameter-dictionary');
 
 
 var cache = {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "devDependencies": {
     "codeclimate-test-reporter": "^0.1.0",
     "istanbul": "^0.3.19",
-    "jasmine-node": "^1.14.5"
+    "jasmine-node": "^1.14.5",
+    "proxyquire": "^1.8.0"
   },
   "scripts": {
     "unit": "./node_modules/.bin/jasmine-node test",

--- a/test/custom-dictionary.json
+++ b/test/custom-dictionary.json
@@ -1,0 +1,22 @@
+{
+    "applications": [
+        {
+            "code": 0,
+            "name": "Custom dictionary app"
+        }
+    ],
+    "avps": [
+        {
+            "code": 1,
+            "name": "Custom-Dictionary-AVP",
+            "vendorId": 0,
+            "type": "UTF8String",
+            "flags": {
+                "mandatory": true,
+                "protected": false,
+                "mayEncrypt": false,
+                "vendorBit": false
+            }
+        }
+    ]
+}

--- a/test/diameter-dictionary-spec.js
+++ b/test/diameter-dictionary-spec.js
@@ -1,5 +1,6 @@
 var dictionary = require('../lib/diameter-dictionary');
 var _ = require('lodash');
+var proxyquire = require('proxyquire');
 
 describe('diameter-dictionary', function () {
 
@@ -81,6 +82,24 @@ describe('diameter-dictionary', function () {
                 protected: true,
                 mayEncrypt: true,
                 vendorBit: true
+            }
+        });
+    });
+
+    it('uses custom dictionary', function() {
+        process.env.DIAMETER_DICTIONARY = '../test/custom-dictionary.json';
+        var customDictionary = proxyquire('../lib/diameter-dictionary', {});
+        var avp = customDictionary.getAvpByCode(1);
+        expect(avp).toEqual({
+            code: 1,
+            name: 'Custom-Dictionary-AVP',
+            vendorId: 0,
+            type: 'UTF8String',
+            flags: {
+                mandatory: true,
+                protected: false,
+                mayEncrypt: false,
+                vendorBit: false
             }
         });
     });


### PR DESCRIPTION
Lets you use a custom dictionary, through setting the env variable (see readme diff). 

I tested it manually, but unfortunately found no elegant way to write a unit test, because of node's 'require' caching. 

Resolves #45 