### PR TITLE
Fixes handling multiple messages in same data event

### DIFF
--- a/lib/diameter-connection.js
+++ b/lib/diameter-connection.js
@@ -33,10 +33,9 @@ function DiameterConnection(options, socket) {
         try {
             buffer = Buffer.concat([buffer, data instanceof Buffer ? data : new Buffer(data)]);
 
-            // If we collected header
-            if (buffer.length >= DIAMETER_MESSAGE_HEADER_LENGTH_IN_BYTES) {
+            while (buffer.length >= DIAMETER_MESSAGE_HEADER_LENGTH_IN_BYTES) {
                 var messageLength = diameterCodec.decodeMessageHeader(buffer).header.length;
-
+                
                 // If we collected the entire message
                 if (buffer.length >= messageLength) {
                     var message = diameterCodec.decodeMessage(buffer);
@@ -75,6 +74,11 @@ function DiameterConnection(options, socket) {
                         }
                     }
                     buffer = buffer.slice(messageLength);
+                } else {
+                    // Header has been collected in the buffer, but not the entire message.
+                    // So, end this event handler, and wait for another data event, with the
+                    // rest of the message. 
+                    return;
                 }
             }
         } catch (err) {

--- a/test/diameter-connection-spec.js
+++ b/test/diameter-connection-spec.js
@@ -1,0 +1,128 @@
+var DiameterConnection = require('../lib/diameter-connection').DiameterConnection;
+var codec = require('../lib/diameter-codec');
+
+
+describe('diameter-connection', function () {
+
+    it('handles traffic', function (done) {
+        var mockClientSocket = createMockSocket();
+        var mockServerSocket = createMockSocket();
+        
+        mockServerSocket.on('diameterMessage', function(event) {
+            if (event.message.command === 'Capabilities-Exchange') {
+                event.response.body = event.response.body.concat(createCEA());
+                event.callback(event.response);
+            }
+        });
+
+        var clientConnection = new DiameterConnection({}, mockClientSocket);
+        var serverConnection = new DiameterConnection({}, mockServerSocket);
+        
+        var request = createCER(clientConnection);
+        var responsePromise = clientConnection.sendRequest(request);
+
+        mockServerSocket.eventHandlers['data'](mockClientSocket.buffer);
+        setImmediate(function() {
+            mockClientSocket.eventHandlers['data'](mockServerSocket.buffer);
+            done();
+        });
+    });
+
+    it('multiple requests in same buffer', function (done) {
+        var mockClientSocket = createMockSocket();
+        var mockServerSocket = createMockSocket();
+        
+        mockServerSocket.on('diameterMessage', function(event) {
+            if (event.message.command === 'Capabilities-Exchange') {
+                event.response.body = event.response.body.concat(createCEA());
+                event.callback(event.response);
+            }
+        });
+
+        var clientConnection = new DiameterConnection({}, mockClientSocket);
+        var serverConnection = new DiameterConnection({}, mockServerSocket);
+        
+        for (var i = 0; i < 5; i++) {
+            var request = createCER(clientConnection);
+            var responsePromise = clientConnection.sendRequest(request);
+        }
+
+        mockServerSocket.eventHandlers['data'](mockClientSocket.buffer);
+        setImmediate(function() {
+            mockClientSocket.eventHandlers['data'](mockServerSocket.buffer);
+            done();
+        });
+    });
+
+    it('connection receiving data in chunks', function (done) {
+        var mockClientSocket = createMockSocket();
+        var mockServerSocket = createMockSocket();
+        
+        mockServerSocket.on('diameterMessage', function(event) {
+            if (event.message.command === 'Capabilities-Exchange') {
+                event.response.body = event.response.body.concat(createCEA());
+                event.callback(event.response);
+            }
+        });
+
+        var clientConnection = new DiameterConnection({}, mockClientSocket);
+        var serverConnection = new DiameterConnection({}, mockServerSocket);
+        
+        for (var i = 0; i < 5; i++) {
+            var request = createCER(clientConnection);
+            var responsePromise = clientConnection.sendRequest(request);
+        }
+
+        mockServerSocket.eventHandlers['data'](mockClientSocket.buffer);
+        setImmediate(function() {
+            for (var j = 0; j < mockServerSocket.buffer.length; j++) {
+                var chunk = mockServerSocket.buffer.slice(j, j + 1);
+                mockClientSocket.eventHandlers['data'](chunk);
+            }
+            done();
+        });
+    });
+
+    var createCER = function(connection) {
+        var request = connection.createRequest('Diameter Common Messages', 'Capabilities-Exchange');
+        request.body = request.body.concat([
+            [ 'Origin-Host', 'gx.pcef.example.com' ],
+            [ 'Origin-Realm', 'pcef.example.com' ],
+            [ 'Vendor-Id', 10415 ],
+            [ 'Origin-State-Id', 219081 ],
+            [ 'Supported-Vendor-Id', 10415 ],
+            [ 'Auth-Application-Id', 'Diameter Credit Control Application' ]
+        ]);
+        return request;
+    };
+
+    var createCEA = function() {
+        return [
+            ['Result-Code', 'DIAMETER_SUCCESS'],
+            ['Origin-Host', 'test.com'],
+            ['Origin-Realm', 'com'],
+            ['Host-IP-Address', '2001:db8:3312::1'],
+            ['Host-IP-Address', '1.2.3.4'],
+            ['Vendor-Id', 123],
+            ['Product-Name', 'node-diameter']
+        ];
+    };
+
+    var createMockSocket = function() {
+        return mockSocket = {
+            eventHandlers: {},
+            buffer: new Buffer(0),
+            on: function(eventName, eventHandler) {
+                this.eventHandlers[eventName] = eventHandler;
+            },
+            emit: function(eventName, data) {
+                var handler = this.eventHandlers[eventName];
+                if (handler !== undefined) handler(data);
+            },
+            write: function(data) {
+                this.buffer = Buffer.concat([this.buffer, data instanceof Buffer ? data : new Buffer(data)]);
+            }
+        };
+    };
+
+});


### PR DESCRIPTION
It turns out that you can receive multiple messages in the same socket 'data' event (in retrospect, no idea why I thought you couldn't).  

This is what was causing errors when you just try to send a bunch of messages in a row. DiameterConnection would just handle the first message in the buffer, and then wait forever for another 'data' even, which would never come, because all messages were in the first 'data' event. 

I think it might resolve several of the old open issues. 

Tests are rudimentary, could use a lot more checks, but I'll be working on improving them when I have time. For now, they show the point. 