### PR TITLE
fix nagle efficiency

### DIFF
--- a/lib/diameter-connection.js
+++ b/lib/diameter-connection.js
@@ -38,8 +38,9 @@ function DiameterConnection(options, socket) {
                 var messageLength = diameterCodec.decodeMessageHeader(buffer).header.length;
 
                 // If we collected the entire message
-                if (buffer.length >= messageLength) {
+                while (buffer.length >= messageLength) {
                     var message = diameterCodec.decodeMessage(buffer);
+                    buffer = buffer.slice(messageLength);
 
                     if (message.header.flags.request) {
                         var response = diameterCodec.constructResponse(message);
@@ -74,7 +75,6 @@ function DiameterConnection(options, socket) {
                             // handle this
                         }
                     }
-                    buffer = buffer.slice(messageLength);
                 }
             }
         } catch (err) {


### PR DESCRIPTION
when a sender sends data too fast, nagle algorithm will kick in
without this loop, the receiver will be too slow to process the amount of data coming in
client will then end up in a timeout situation
the if() here is totally wrong 