### PR TITLE
Correct coding of ip address, string input for octetstring

### DIFF
--- a/lib/diameter-types.js
+++ b/lib/diameter-types.js
@@ -7,8 +7,12 @@ var ipaddr = require('ipaddr.js');
 
 var types = {
     'OctetString': {
-        encode: function(value) {
-            return value;
+       encode: function(value) {
+			if (typeof value == 'string'){
+				return Buffer.from(value)
+			} else {
+				return value;
+			}
         },
         decode: function(buffer) {
             return buffer;
@@ -87,6 +91,8 @@ var types = {
     'IPAddress': {
         encode: function(value) {
             var ip = ipaddr.parse(value);
+			return Buffer.from(ip.toByteArray());
+			/*
             var typeBuffer = new Buffer(2);
             typeBuffer.writeUInt8(0, 0);
             if (ip.kind() === 'ipv4') {
@@ -96,8 +102,12 @@ var types = {
                 typeBuffer.writeUInt8(2, 1);
                 return Buffer.concat([typeBuffer, new Buffer(ip.toByteArray())]);
             }
+			*/
         },
         decode: function(buffer) {
+			var ip = ipaddr.fromByteArray(new Uint32Array(buffer));
+			return ip.toString();
+		/*
             var octetsArray = [];
             for (var i = 0; i < buffer.length; i++) {
                 octetsArray.push(buffer.readUInt8(i));
@@ -118,6 +128,7 @@ var types = {
                 });
                 return new ipaddr.IPv6(parts).toString();
             }
+		*/
         }
     }
 };


### PR DESCRIPTION
According to RFC3588, ip addresses have to be encoded as octetstring of the integer representation and not of the dotted decimal representation.
octetstring now supports input with type string. The string will be converted to byte array.