### PR TITLE
Eliminating exception when decoding optional AVP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ npm-debug.log
 node_modules
 coverage
 .vscode
-package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ npm-debug.log
 node_modules
 coverage
 .vscode
-
+package-lock.json

--- a/lib/diameter-codec.js
+++ b/lib/diameter-codec.js
@@ -202,35 +202,42 @@ var decodeAvp = function(buffer, start, appId) {
         avp.vendorId = 0;
     }
 
-    var avpTag = dictionary.getAvpByCodeAndVendorId(avp.codeInt, avp.vendorId);
-    if (avpTag == null) {
-        throw new Error('Unable to find AVP for code ' + avp.codeInt + ' and vendor id ' + avp.vendorId + ', for app ' + appId);
-    }
-    avp.code = avpTag.name;
+    try {
+        var avpTag = dictionary.getAvpByCodeAndVendorId(avp.codeInt, avp.vendorId);
+        if (avpTag == null) {
+            throw new Error('Unable to find AVP for code ' + avp.codeInt + ' and vendor id ' + avp.vendorId + ', for app ' + appId);
+        }
+        avp.code = avpTag.name;
 
-    var dataPosition = hasVendorId ? DIAMETER_MESSAGE_AVP_VENDOR_ID_DATA : DIAMETER_MESSAGE_AVP_NO_VENDOR_ID_DATA;
+        var dataPosition = hasVendorId ? DIAMETER_MESSAGE_AVP_VENDOR_ID_DATA : DIAMETER_MESSAGE_AVP_NO_VENDOR_ID_DATA;
 
-    avp.dataRaw = buffer.slice(start + dataPosition, start + avp.length);
-    if (avpTag.type === 'Grouped') {
-        avp.avps = decodeAvps(avp.dataRaw, 0, avp.dataRaw.length, appId);
-    } else {
-        avp.data = diameterTypes.decode(avpTag.type, avp.dataRaw);
-        if (avpTag.type === 'AppId') {
-            var application = dictionary.getApplicationById(avp.data);
-            if (application == null) {
-                throw new Error('Can\'t find application with ID ' + avp.data);
+        avp.dataRaw = buffer.slice(start + dataPosition, start + avp.length);
+        if (avpTag.type === 'Grouped') {
+            avp.avps = decodeAvps(avp.dataRaw, 0, avp.dataRaw.length, appId);
+        } else {
+            avp.data = diameterTypes.decode(avpTag.type, avp.dataRaw);
+            if (avpTag.type === 'AppId') {
+                var application = dictionary.getApplicationById(avp.data);
+                if (application == null) {
+                    throw new Error('Can\'t find application with ID ' + avp.data);
+                }
+                avp.data = application.name;
+            } else if (avpTag.enums) {
+                var enumValue = _.find(avpTag.enums, {
+                    code: avp.data
+                });
+                if (enumValue == null) {
+                    throw new Error('No enum value found for ' + avp.code + ' code ' + avp.data);
+                }
+                avp.data = enumValue.name;
             }
-            avp.data = application.name;
-        } else if (avpTag.enums) {
-            var enumValue = _.find(avpTag.enums, {
-                code: avp.data
-            });
-            if (enumValue == null) {
-                throw new Error('No enum value found for ' + avp.code + ' code ' + avp.data);
-            }
-            avp.data = enumValue.name;
+        }
+    } catch (err) {
+        if (avp.flags.mandatory) {
+            throw err;
         }
     }
+
     return avp;
 };
 

--- a/test/diameter-codec-spec.js
+++ b/test/diameter-codec-spec.js
@@ -37,5 +37,17 @@ describe('diameter-codec', function() {
             expect(decoded.code).toBe('Auth-Application-Id');
             expect(decoded.data).toBe('Diameter Credit Control Application');
         });
+
+        it('decodes non mandartory avp ', function() {
+            var buffer = new Buffer('000009a4800000100000014300000080', 'hex');
+            var decoded = codec.decodeAvp(buffer, 0);
+            expect(decoded.code).toBe('DSR-ApplicationInvoked');
+            expect(decoded.data).toBe(128);
+        });
+
+        it('decodes non mandartory avp ', function() {
+            var buffer = new Buffer('000001154000000c000000ff', 'hex');
+            expect(() => { codec.decodeAvp(buffer, 0) }).toThrow(new Error('No enum value found for Auth-Session-State code 255'));
+        });
     });
 });

--- a/test/diameter-codec-spec.js
+++ b/test/diameter-codec-spec.js
@@ -45,7 +45,7 @@ describe('diameter-codec', function() {
             expect(decoded.data).toBe(128);
         });
 
-        it('decodes mandartory AVP with unknown enum value ', function() {
+        it('decodes mandatory AVP with unknown enum value ', function() {
             var buffer = new Buffer('000001154000000c000000ff', 'hex');
             expect(() => { codec.decodeAvp(buffer, 0) }).toThrow(new Error('No enum value found for Auth-Session-State code 255'));
         });

--- a/test/diameter-codec-spec.js
+++ b/test/diameter-codec-spec.js
@@ -38,14 +38,14 @@ describe('diameter-codec', function() {
             expect(decoded.data).toBe('Diameter Credit Control Application');
         });
 
-        it('decodes non mandartory avp ', function() {
+        it('decodes non-mandatory AVP ', function() {
             var buffer = new Buffer('000009a4800000100000014300000080', 'hex');
             var decoded = codec.decodeAvp(buffer, 0);
             expect(decoded.code).toBe('DSR-ApplicationInvoked');
             expect(decoded.data).toBe(128);
         });
 
-        it('decodes non mandartory avp ', function() {
+        it('decodes mandartory AVP with unknown enum value ', function() {
             var buffer = new Buffer('000001154000000c000000ff', 'hex');
             expect(() => { codec.decodeAvp(buffer, 0) }).toThrow(new Error('No enum value found for Auth-Session-State code 255'));
         });

--- a/test/diameter-codec-spec.js
+++ b/test/diameter-codec-spec.js
@@ -38,7 +38,7 @@ describe('diameter-codec', function() {
             expect(decoded.data).toBe('Diameter Credit Control Application');
         });
 
-        it('decodes non-mandatory AVP ', function() {
+        it('decodes non-mandatory AVP', function() {
             var buffer = new Buffer('000009a4800000100000014300000080', 'hex');
             var decoded = codec.decodeAvp(buffer, 0);
             expect(decoded.code).toBe('DSR-ApplicationInvoked');


### PR DESCRIPTION
Throwing an Error in decodeAvp function is not really the best way of handling unknown AVPs or unknown Enums, this will drop the whole diameter message because of a problematic AVP which most probably is optional. So the easiest way of reducing the number of Errors is just checking AVP flags and throwing Error when AVP is mandatory otherwise silently move to the next AVP.

This simple change will eliminate some of the network timeout errors.