### PR TITLE
Do not add Session-Id to CER

### DIFF
--- a/lib/diameter-codec.js
+++ b/lib/diameter-codec.js
@@ -145,7 +145,9 @@ exports.constructRequest = function(applicationName, commandName, sessionId) {
         command: command.name
     };
 
-    request.body.push(['Session-Id', sessionId.toString()]);
+    if (sessionId !== undefined) {
+        request.body.push(['Session-Id', sessionId.toString()]);
+    };
 
     return request;
 };

--- a/lib/diameter-connection.js
+++ b/lib/diameter-connection.js
@@ -88,7 +88,12 @@ function DiameterConnection(options, socket) {
 
     self.createRequest = function(application, command, sessionId) {
         if (sessionId === undefined) {
-            sessionId = diameterUtil.random32BitNumber();
+            if (command === 'Capabilities-Exchange') {
+                return diameterCodec.constructRequest(application, command);
+            } else {
+                sessionId = diameterUtil.random32BitNumber();
+            }
+            
         }
         return diameterCodec.constructRequest(application, command, sessionId);
     };


### PR DESCRIPTION
According to [RFC 6733 p. 5.3.1](https://www.rfc-editor.org/rfc/rfc6733.html#page-62), Session-Id is not set in CERs.

I encountered an issue when a commercial DRA rejected CERs while building a test environment for my work.

So, I added a check for Command Code Capabilities-Exchange-Request.